### PR TITLE
Authentication not set in Guzzle

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -192,9 +192,7 @@ class Api
         $this->baseUrl = sprintf('https://%s.freshdesk.com/api/v2', $domain);
 
         $this->client = new Client([
-                'defaults' => [
-                    'auth' => [$apiKey, 'X']
-                ]
+                'auth' => [$apiKey, 'X']
             ]
         );
 


### PR DESCRIPTION
The config params for authentication are not set in the Guzzle Client.
This fixes the problem. Apparently 'defaults' is not processed in Guzzle 6.2
