### PR TITLE
Allow paginating Ticket search

### DIFF
--- a/src/Resources/Ticket.php
+++ b/src/Resources/Ticket.php
@@ -138,6 +138,7 @@ class Ticket extends AbstractResource
      *
      * @api
      * @param string $filtersQuery
+     * @param int $page The page number (1 to 10)
      * @return array|null
      * @throws \Freshdesk\Exceptions\AccessDeniedException
      * @throws \Freshdesk\Exceptions\ApiException
@@ -150,11 +151,12 @@ class Ticket extends AbstractResource
      * @throws \Freshdesk\Exceptions\UnsupportedAcceptHeaderException
      * @throws \Freshdesk\Exceptions\ValidationException
      */
-    public function search(string $filtersQuery)
+    public function search(string $filtersQuery, $page = 1)
     {
         $end = '/search'.$this->endpoint();
         $query = [
             'query' => '"'.$filtersQuery.'"',
+            'page' => $page
         ];
         return $this->api()->request('GET', $end, null, $query);
     }


### PR DESCRIPTION
The ticket Filter  API (https://developers.freshdesk.com/api/#filter_tickets) allows pagination by providing a 'page' parameter on the url, but this SDK doesn't support that. 